### PR TITLE
Use vuejs-logger within vuex store

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'import/prefer-default-export': 'off',
     'no-unused-expressions': ['error', { allowShortCircuit: true }],
+    'no-underscore-dangle': ['error', { allow: ['_vm'] }],
     'max-len': [2, 120, 2, {
       ignoreUrls: true,
       ignoreStrings: true,

--- a/src/$log.d.ts
+++ b/src/$log.d.ts
@@ -1,0 +1,13 @@
+import Vue from 'vue';
+
+declare module 'vue/types/vue' {
+  export interface VueConstructor<V extends Vue = Vue> {
+    $log: {
+      debug(...args: any[]): void;
+      info(...args: any[]): void;
+      warn(...args: any[]): void;
+      error(...args: any[]): void;
+      fatal(...args: any[]): void;
+    };
+  }
+}

--- a/src/store/modules/gateway/actions.ts
+++ b/src/store/modules/gateway/actions.ts
@@ -2,6 +2,7 @@ import { Commit, ActionPayload } from 'vuex';
 import { AppGatewayServiceClient } from '@hwsc/hwsc-api-blocks/protobuf/hwsc-app-gateway-svc/app/hwsc-app-gateway-svcServiceClientPb';
 import { AppGatewayServiceRequest } from '@hwsc/hwsc-api-blocks/protobuf/hwsc-app-gateway-svc/app/hwsc-app-gateway-svc_pb';
 import * as grpc from 'grpc-web';
+import Vue from 'vue';
 import * as headers from '@/consts/headers';
 import * as constants from '@/consts/keys';
 import * as mutation from '@/store/modules/gateway/types-mutations';
@@ -20,13 +21,12 @@ export const actions = {
   [action.INIT_AUTH_HEADER]({ state, commit }: ActionContext): Promise<any> {
     let token: string | null = window.localStorage.getItem(constants.LOCAL_STORAGE_TOKEN_KEY);
     let authType: string = headers.USER_AUTH;
-
     if (!token) {
       const dummyEmail: string | undefined = process.env.VUE_APP_DUMMY_EMAIL;
       const dummyPassword: string | undefined = process.env.VUE_APP_DUMMY_PASSWORD;
-
       if (!dummyEmail || !dummyPassword) {
         // TODO route to error 50X page
+        Vue.$log.error('undefined environment variable for registration');
         return Promise.reject(
           new Error('VUE_APP_DUMMY_EMAIL &/or VUE_APP_DUMMY_PASSWORD not loaded'),
         );
@@ -44,7 +44,7 @@ export const actions = {
     const hostname: string = process.env.VUE_APP_HOST_NAME || '';
 
     if (!hostname) {
-      // TODO route to error 50X page
+      Vue.$log.error('undefined environment variable for app gateway');
       return Promise.reject(
         new Error('VUE_APP_HOST_NAME not loaded'),
       );
@@ -60,6 +60,7 @@ export const actions = {
       const request: AppGatewayServiceRequest = new AppGatewayServiceRequest();
       state.grpcClient.getStatus(request, state.authHeader, (err: any, res: any) => {
         if (err) {
+          Vue.$log.error('app gateway get status failure');
           reject(err);
         } else {
           resolve(res);

--- a/src/store/modules/gateway/actions.ts
+++ b/src/store/modules/gateway/actions.ts
@@ -44,6 +44,7 @@ export const actions = {
     const hostname: string = process.env.VUE_APP_HOST_NAME || '';
 
     if (!hostname) {
+      // TODO route to error 50X page
       Vue.$log.error('undefined environment variable for app gateway');
       return Promise.reject(
         new Error('VUE_APP_HOST_NAME not loaded'),


### PR DESCRIPTION
A single instance of vuejs-logger globally defined plugin should only be used for logging in Vuex store.

Closes https://github.com/hwsc-org/hwsc-frontend/issues/39

![Screen Shot 2019-09-03 at 00 59 04](https://user-images.githubusercontent.com/16410475/64154640-1b8e6600-cde6-11e9-8625-e450cf4fc36d.png)
